### PR TITLE
fix: address issues #11-#14

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ for _, stmt := range stmts {
 }
 ```
 
+### UUID Primary Keys
+
+For Postgres apps using UUID primary keys:
+
+```go
+schema.UUIDPKCol("id")
+// Postgres: id UUID PRIMARY KEY DEFAULT gen_random_uuid()
+// SQLite:   id TEXT PRIMARY KEY
+```
+
 ### Foreign Key References
 
 `References` defines a foreign key. Chain `OnDelete` and `OnUpdate` for referential actions:
@@ -352,18 +362,25 @@ query := "SELECT * FROM Users " + w.String()
 // "SELECT * FROM Users WHERE DepartmentID = @DeptID AND Name LIKE @Pattern"
 ```
 
+Set a dialect for dialect-aware behavior (e.g. ILIKE on Postgres):
+
+```go
+w := dbrepo.NewWhere().WithDialect(dialect)
+```
+
 Semantic filter methods encode domain patterns. Each accepts an optional column name override for custom naming:
 
 ```go
-w := dbrepo.NewWhere().
+w := dbrepo.NewWhere().WithDialect(dialect).
     NotDeleted().                  // DeletedAt IS NULL
-    NotArchived().                 // ArchivedAt IS NULL
+    NotArchived().                 // ArchivedAt IS NULL (timestamp column)
+    NotArchivedBool().             // NOT archived (boolean column)
     NotExpired().                  // ExpiresAt IS NULL OR ExpiresAt > CURRENT_TIMESTAMP
     HasStatus("active").           // Status = @Status
     HasVersion(3).                 // Version = @Version
     IsRoot().                      // ParentID IS NULL
     NotReplaced().                 // ReplacedByID IS NULL
-    Search("fraggle", "Name", "Bio")  // (Name LIKE @SearchPattern OR Bio LIKE @SearchPattern)
+    Search("fraggle", "Name", "Bio")  // Postgres: ILIKE, others: LIKE
 
 // Snake-case schemas: pass the column name
 w := dbrepo.NewWhere().

--- a/dbrepo/where.go
+++ b/dbrepo/where.go
@@ -5,17 +5,26 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/catgoose/fraggle"
 )
 
 // WhereBuilder constructs composable WHERE clauses with named parameters.
 type WhereBuilder struct {
 	clauses []string
 	args    []any
+	dialect fraggle.Dialect
 }
 
 // NewWhere creates a new WhereBuilder.
 func NewWhere() *WhereBuilder {
 	return &WhereBuilder{}
+}
+
+// WithDialect sets the dialect for dialect-aware operations (e.g. ILIKE on Postgres).
+func (w *WhereBuilder) WithDialect(d fraggle.Dialect) *WhereBuilder {
+	w.dialect = d
+	return w
 }
 
 // And adds an AND condition with optional named args.
@@ -61,6 +70,7 @@ func (w *WhereBuilder) OrIf(ok bool, condition string, args ...any) *WhereBuilde
 var validIdentifier = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_.]*$`)
 
 // Search adds a LIKE search condition across the given fields.
+// When a dialect is set via WithDialect, Postgres uses ILIKE for case-insensitive matching.
 // Field names are validated to prevent SQL injection — only alphanumeric characters,
 // underscores, and dots (for qualified names) are allowed.
 func (w *WhereBuilder) Search(search string, fields ...string) *WhereBuilder {
@@ -68,12 +78,16 @@ func (w *WhereBuilder) Search(search string, fields ...string) *WhereBuilder {
 		return w
 	}
 	pattern := "%" + search + "%"
+	op := "LIKE"
+	if w.dialect != nil && w.dialect.Engine() == fraggle.Postgres {
+		op = "ILIKE"
+	}
 	var conditions []string
 	for _, field := range fields {
 		if !validIdentifier.MatchString(field) {
 			continue
 		}
-		conditions = append(conditions, fmt.Sprintf("%s LIKE @SearchPattern", field))
+		conditions = append(conditions, fmt.Sprintf("%s %s @SearchPattern", field, op))
 	}
 	if len(conditions) == 0 {
 		return w
@@ -161,6 +175,17 @@ func (w *WhereBuilder) ReplacedBy(id int64, col ...string) *WhereBuilder {
 // Pass an optional column name to override the default "ArchivedAt".
 func (w *WhereBuilder) NotArchived(col ...string) *WhereBuilder {
 	return w.And(colName("ArchivedAt", col) + " IS NULL")
+}
+
+// NotArchivedBool adds a condition for boolean archived columns.
+// Generates "NOT archived" for Postgres/SQLite, "archived = 0" for MSSQL.
+// Pass an optional column name to override the default "archived".
+func (w *WhereBuilder) NotArchivedBool(col ...string) *WhereBuilder {
+	c := colName("archived", col)
+	if w.dialect != nil && w.dialect.Engine() == fraggle.MSSQL {
+		return w.And(c + " = 0")
+	}
+	return w.And("NOT " + c)
 }
 
 // HasVersion adds a "Version = @Version" condition for optimistic locking.

--- a/dbrepo/where_test.go
+++ b/dbrepo/where_test.go
@@ -3,6 +3,7 @@ package dbrepo
 import (
 	"testing"
 
+	"github.com/catgoose/fraggle"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -195,5 +196,44 @@ func TestWhereSearch(t *testing.T) {
 		w := NewWhere().Search("gobo", "t.Name", "u.Email")
 		assert.Contains(t, w.String(), "t.Name LIKE @SearchPattern")
 		assert.Contains(t, w.String(), "u.Email LIKE @SearchPattern")
+	})
+
+	t.Run("postgres_uses_ilike", func(t *testing.T) {
+		w := NewWhere().WithDialect(fraggle.PostgresDialect{}).Search("gobo", "Name", "Email")
+		assert.Contains(t, w.String(), "Name ILIKE @SearchPattern")
+		assert.Contains(t, w.String(), "Email ILIKE @SearchPattern")
+		assert.NotContains(t, w.String(), " LIKE ")
+	})
+
+	t.Run("sqlite_uses_like", func(t *testing.T) {
+		w := NewWhere().WithDialect(fraggle.SQLiteDialect{}).Search("gobo", "Name")
+		assert.Contains(t, w.String(), "Name LIKE @SearchPattern")
+	})
+
+	t.Run("no_dialect_uses_like", func(t *testing.T) {
+		w := NewWhere().Search("gobo", "Name")
+		assert.Contains(t, w.String(), "Name LIKE @SearchPattern")
+	})
+}
+
+func TestWhereNotArchivedBool(t *testing.T) {
+	t.Run("default_column", func(t *testing.T) {
+		w := NewWhere().NotArchivedBool()
+		assert.Equal(t, "WHERE NOT archived", w.String())
+	})
+
+	t.Run("custom_column", func(t *testing.T) {
+		w := NewWhere().NotArchivedBool("is_archived")
+		assert.Equal(t, "WHERE NOT is_archived", w.String())
+	})
+
+	t.Run("mssql_uses_equals_zero", func(t *testing.T) {
+		w := NewWhere().WithDialect(fraggle.MSSQLDialect{}).NotArchivedBool()
+		assert.Equal(t, "WHERE archived = 0", w.String())
+	})
+
+	t.Run("postgres_uses_not", func(t *testing.T) {
+		w := NewWhere().WithDialect(fraggle.PostgresDialect{}).NotArchivedBool()
+		assert.Equal(t, "WHERE NOT archived", w.String())
 	})
 }

--- a/schema/column.go
+++ b/schema/column.go
@@ -108,6 +108,29 @@ func AutoIncrCol(name string) ColumnDef {
 	}
 }
 
+// TypeUUIDPK returns a TypeFunc for a UUID primary key column.
+// This embeds PRIMARY KEY in the type definition, similar to TypeAutoIncrement.
+func TypeUUIDPK() TypeFunc {
+	return func(d fraggle.Dialect) string {
+		if d.Engine() == fraggle.Postgres {
+			return "UUID PRIMARY KEY DEFAULT gen_random_uuid()"
+		}
+		return d.UUIDType() + " PRIMARY KEY"
+	}
+}
+
+// UUIDPKCol creates a UUID primary key column (immutable).
+// On Postgres this generates: id UUID PRIMARY KEY DEFAULT gen_random_uuid()
+// On other engines it uses the engine's UUID type with PRIMARY KEY.
+func UUIDPKCol(name string) ColumnDef {
+	return ColumnDef{
+		name:    name,
+		typeFn:  TypeUUIDPK(),
+		pk:      true,
+		mutable: false,
+	}
+}
+
 // NotNull marks the column as NOT NULL.
 func (c ColumnDef) NotNull() ColumnDef { c.notNull = true; return c }
 
@@ -160,7 +183,9 @@ func (c ColumnDef) ddl(d fraggle.Dialect) string {
 	}
 
 	if c.defaultFn != nil {
-		parts = append(parts, fmt.Sprintf("DEFAULT %s", c.defaultFn(d)))
+		if v := c.defaultFn(d); v != "" {
+			parts = append(parts, fmt.Sprintf("DEFAULT %s", v))
+		}
 	} else if c.defaultVal != "" {
 		parts = append(parts, fmt.Sprintf("DEFAULT %s", c.defaultVal))
 	}

--- a/schema/snapshot.go
+++ b/schema/snapshot.go
@@ -46,7 +46,7 @@ type TableSnapshot struct {
 // for CI validation.
 func (t *TableDef) Snapshot(d fraggle.Dialect) TableSnapshot {
 	snap := TableSnapshot{
-		Name:          t.Name,
+		Name:          d.NormalizeIdentifier(t.Name),
 		HasSoftDelete: t.hasSoftDelete,
 		HasVersion:    t.hasVersion,
 		HasExpiry:     t.hasExpiry,

--- a/schema/snapshot_test.go
+++ b/schema/snapshot_test.go
@@ -26,7 +26,7 @@ func TestSnapshot(t *testing.T) {
 	t.Run("struct_fields", func(t *testing.T) {
 		snap := table.Snapshot(fraggle.PostgresDialect{})
 
-		assert.Equal(t, "Tasks", snap.Name)
+		assert.Equal(t, "tasks", snap.Name)
 		assert.True(t, snap.HasSoftDelete)
 		assert.True(t, snap.HasVersion)
 		require.Len(t, snap.Columns, 7) // ID, Title, UserID, CreatedAt, UpdatedAt, DeletedAt, Version
@@ -88,7 +88,7 @@ func TestSnapshotString(t *testing.T) {
 
 	s := table.SnapshotString(fraggle.PostgresDialect{})
 
-	assert.Contains(t, s, "TABLE Users")
+	assert.Contains(t, s, "TABLE users")
 	assert.Contains(t, s, "id")
 	assert.Contains(t, s, "PRIMARY KEY")
 	assert.Contains(t, s, "email")
@@ -148,6 +148,6 @@ func TestSchemaSnapshot(t *testing.T) {
 
 	snaps := SchemaSnapshot(fraggle.PostgresDialect{}, users, tasks)
 	require.Len(t, snaps, 2)
-	assert.Equal(t, "Users", snaps[0].Name)
-	assert.Equal(t, "Tasks", snaps[1].Name)
+	assert.Equal(t, "users", snaps[0].Name)
+	assert.Equal(t, "tasks", snaps[1].Name)
 }

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -287,6 +287,26 @@ func TestColumnDDL(t *testing.T) {
 		assert.Contains(t, ddl, "id")
 		assert.Contains(t, ddl, "SERIAL PRIMARY KEY")
 	})
+
+	t.Run("uuid_pk_postgres", func(t *testing.T) {
+		c := UUIDPKCol("ID")
+		ddl := c.ddl(d)
+		assert.Contains(t, ddl, "UUID PRIMARY KEY DEFAULT gen_random_uuid()")
+	})
+
+	t.Run("uuid_pk_sqlite", func(t *testing.T) {
+		c := UUIDPKCol("ID")
+		sq := fraggle.SQLiteDialect{}
+		ddl := c.ddl(sq)
+		assert.Contains(t, ddl, "TEXT PRIMARY KEY")
+		assert.NotContains(t, ddl, "gen_random_uuid")
+	})
+
+	t.Run("uuid_pk_immutable", func(t *testing.T) {
+		c := UUIDPKCol("ID")
+		assert.True(t, c.pk)
+		assert.False(t, c.mutable)
+	})
 }
 
 func TestTableFactories(t *testing.T) {

--- a/schema/validate_test.go
+++ b/schema/validate_test.go
@@ -113,15 +113,72 @@ func TestValidateSchemaPostgresNormalization(t *testing.T) {
 	errs := ValidateSchema(ctx, db, d, table)
 	assert.Nil(t, errs)
 
-	// Verify Postgres normalization produces snake_case names
+	// Verify Postgres normalization produces snake_case names in Snapshot
 	pg := fraggle.PostgresDialect{}
 	snap := table.Snapshot(pg)
+	assert.Equal(t, "accounts", snap.Name)
 	assert.Equal(t, "email", snap.Columns[1].Name)
 	assert.Equal(t, "password_hash", snap.Columns[2].Name)
 
 	// TableNameFor should also normalize
 	assert.Equal(t, "accounts", table.TableNameFor(pg))
 	assert.Equal(t, "Accounts", table.TableNameFor(d))
+}
+
+func TestValidateSchemaIssue11Repro(t *testing.T) {
+	// Issue #11: ValidateSchema should normalize CamelCase column names through
+	// the dialect before comparing against the live database.
+	// On Postgres, DDL creates snake_case columns, so Snapshot must also
+	// produce snake_case names for the comparison to succeed.
+
+	pg := fraggle.PostgresDialect{}
+
+	// Define table with PascalCase names (how users define schemas)
+	table := NewTable("Accounts").
+		Columns(
+			AutoIncrCol("ID"),
+			Col("Email", TypeVarchar(255)).NotNull(),
+			Col("PasswordHash", TypeText()).NotNull(),
+		).
+		WithTimestamps()
+
+	// Snapshot with Postgres dialect must normalize all names
+	snap := table.Snapshot(pg)
+	assert.Equal(t, "accounts", snap.Name)
+	assert.Equal(t, "id", snap.Columns[0].Name)
+	assert.Equal(t, "email", snap.Columns[1].Name)
+	assert.Equal(t, "password_hash", snap.Columns[2].Name)
+	assert.Equal(t, "created_at", snap.Columns[3].Name)
+	assert.Equal(t, "updated_at", snap.Columns[4].Name)
+
+	// SelectColumnsFor must also normalize
+	pgCols := table.SelectColumnsFor(pg)
+	assert.Equal(t, []string{"id", "email", "password_hash", "created_at", "updated_at"}, pgCols)
+
+	// InsertColumnsFor must normalize (excludes auto-increment)
+	pgInsert := table.InsertColumnsFor(pg)
+	assert.Equal(t, []string{"email", "password_hash", "created_at", "updated_at"}, pgInsert)
+
+	// UpdateColumnsFor must normalize (only mutable)
+	pgUpdate := table.UpdateColumnsFor(pg)
+	assert.Contains(t, pgUpdate, "email")
+	assert.Contains(t, pgUpdate, "password_hash")
+	assert.Contains(t, pgUpdate, "updated_at")
+	assert.NotContains(t, pgUpdate, "id")
+	assert.NotContains(t, pgUpdate, "created_at")
+
+	// End-to-end: validate with SQLite (which doesn't normalize) still works
+	// when table and columns match exactly
+	ctx := context.Background()
+	db := openTestDB(t)
+	d := fraggle.SQLiteDialect{}
+
+	for _, stmt := range table.CreateIfNotExistsSQL(d) {
+		_, err := db.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+	errs := ValidateSchema(ctx, db, d, table)
+	assert.Nil(t, errs, "expected no errors, got: %v", errs)
 }
 
 func TestValidateAll(t *testing.T) {


### PR DESCRIPTION
## Summary

- **#11**: Normalize table name in `Snapshot()` for Postgres consistency. Adds tests verifying `SelectColumnsFor`/`InsertColumnsFor`/`UpdateColumnsFor` produce snake_case names that match DDL output.
- **#12**: Add `UUIDPKCol()` helper for UUID primary keys — generates `UUID PRIMARY KEY DEFAULT gen_random_uuid()` on Postgres, `TEXT PRIMARY KEY` on other engines.
- **#13**: `Search()` now uses `ILIKE` on Postgres for case-insensitive matching when dialect is set via `WithDialect()`. Other engines continue using `LIKE`.
- **#14**: Add `NotArchivedBool()` for boolean archived columns — generates `NOT col` (Postgres/SQLite) or `col = 0` (MSSQL).

Closes #11, closes #12, closes #13, closes #14

## Test plan

- [x] `TestValidateSchemaIssue11Repro` verifies Snapshot normalizes table and column names for Postgres
- [x] `TestColumnDDL/uuid_pk_postgres` and `uuid_pk_sqlite` verify UUID PK DDL across dialects
- [x] `TestWhereSearch/postgres_uses_ilike` verifies ILIKE on Postgres
- [x] `TestWhereNotArchivedBool` verifies boolean archive filtering across dialects
- [x] All existing tests pass