### PR TITLE
Split Dialect interface into composable sub-interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,17 @@ import _ "github.com/catgoose/fraggle/driver/mssql"
 
 ## Dialect Interface
 
-Every engine implements the same interface. You get raw SQL strings that you compose into full queries — the generated SQL is predictable because it's just string concatenation with guard rails.
+The `Dialect` interface is composed from focused sub-interfaces. Each sub-interface captures a single responsibility, so functions can accept only the capability they need:
+
+| Interface | Purpose |
+|-----------|---------|
+| `TypeMapper` | Maps Go types to SQL column type strings (`IntType`, `StringType`, `BoolType`, etc.) |
+| `DDLWriter` | Generates DDL statements (`CreateTableIfNotExists`, `DropTableIfExists`, `InsertOrIgnore`, etc.) |
+| `QueryWriter` | Generates query fragments (`Placeholder`, `Pagination`, `Now`, `LastInsertIDQuery`, etc.) |
+| `Identifier` | Handles SQL identifier formatting (`NormalizeIdentifier`, `QuoteIdentifier`) |
+| `Inspector` | Provides schema introspection queries (`TableExistsQuery`, `TableColumnsQuery`) |
+
+`Dialect` composes all five, so passing a `Dialect` still works everywhere. But a function that only quotes identifiers can accept `Identifier` instead, making its dependency explicit and its tests simpler.
 
 ```go
 d, _ := fraggle.New(fraggle.Postgres)
@@ -160,6 +170,28 @@ d.ReturningClause("id, created_at")  // SQLite:   "RETURNING id, created_at"
 fraggle.QuoteColumns(d, "CreatedAt, Title DESC")
 // Postgres: "created_at", "title" DESC
 ```
+
+### Accepting Sub-Interfaces
+
+Functions that only need a subset of `Dialect` can accept a sub-interface directly. This makes dependencies explicit and simplifies testing -- you only need to implement the methods the function actually calls.
+
+```go
+// Only needs identifier quoting -- accepts Identifier, not full Dialect.
+func quotedColumnList(d fraggle.Identifier, cols []string) string {
+    quoted := make([]string, len(cols))
+    for i, c := range cols {
+        quoted[i] = d.QuoteIdentifier(c)
+    }
+    return strings.Join(quoted, ", ")
+}
+
+// Needs type mapping and identifiers -- accepts Dialect (which embeds both).
+func columnDDL(d fraggle.Dialect, name string) string {
+    return d.QuoteIdentifier(name) + " " + d.IntType()
+}
+```
+
+All three implementations (`SQLiteDialect`, `PostgresDialect`, `MSSQLDialect`) satisfy every sub-interface, verified by compile-time checks.
 
 ## Opening Connections
 

--- a/dbrepo/fragments.go
+++ b/dbrepo/fragments.go
@@ -64,7 +64,7 @@ func InsertInto(table string, cols ...string) string {
 // ColumnsQ joins column names into a comma-separated list with dialect quoting.
 //
 //	ColumnsQ(d, "ID", "Name", "Email") => `"ID", "Name", "Email"` (Postgres/SQLite)
-func ColumnsQ(d fraggle.Dialect, cols ...string) string {
+func ColumnsQ(d fraggle.Identifier, cols ...string) string {
 	quoted := make([]string, len(cols))
 	for i, c := range cols {
 		quoted[i] = d.QuoteIdentifier(c)
@@ -75,7 +75,7 @@ func ColumnsQ(d fraggle.Dialect, cols ...string) string {
 // SetClauseQ builds a SET fragment for UPDATE statements with dialect quoting.
 //
 //	SetClauseQ(d, "Name", "Email") => `"Name" = @Name, "Email" = @Email` (Postgres/SQLite)
-func SetClauseQ(d fraggle.Dialect, cols ...string) string {
+func SetClauseQ(d fraggle.Identifier, cols ...string) string {
 	parts := make([]string, len(cols))
 	for i, c := range cols {
 		parts[i] = fmt.Sprintf("%s = @%s", d.QuoteIdentifier(c), c)
@@ -87,7 +87,7 @@ func SetClauseQ(d fraggle.Dialect, cols ...string) string {
 //
 //	InsertIntoQ(d, "Users", "Name", "Email") =>
 //	  `INSERT INTO "Users" ("Name", "Email") VALUES (@Name, @Email)` (Postgres/SQLite)
-func InsertIntoQ(d fraggle.Dialect, table string, cols ...string) string {
+func InsertIntoQ(d fraggle.Identifier, table string, cols ...string) string {
 	return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
 		d.QuoteIdentifier(table), ColumnsQ(d, cols...), Placeholders(cols...))
 }

--- a/fraggle.go
+++ b/fraggle.go
@@ -31,163 +31,69 @@ func ParseEngine(s string) (Engine, error) {
 	}
 }
 
+// TypeMapper maps Go types to SQL column type strings.
+type TypeMapper interface {
+	IntType() string
+	BigIntType() string
+	TextType() string
+	StringType(maxLen int) string
+	VarcharType(maxLen int) string
+	BoolType() string
+	FloatType() string
+	DecimalType(precision, scale int) string
+	TimestampType() string
+	UUIDType() string
+	JSONType() string
+	AutoIncrement() string
+}
+
+// DDLWriter generates DDL statements.
+type DDLWriter interface {
+	CreateTableIfNotExists(table, body string) string
+	DropTableIfExists(table string) string
+	CreateIndexIfNotExists(indexName, table, columns string) string
+	InsertOrIgnore(table, columns, values string) string
+	ReturningClause(columns string) string
+}
+
+// QueryWriter generates query fragments.
+type QueryWriter interface {
+	Placeholder(n int) string
+	Pagination() string
+	Now() string
+	LastInsertIDQuery() string
+	SupportsLastInsertID() bool
+}
+
+// Identifier handles SQL identifier formatting.
+type Identifier interface {
+	NormalizeIdentifier(name string) string
+	QuoteIdentifier(name string) string
+}
+
+// Inspector provides schema introspection queries.
+type Inspector interface {
+	TableExistsQuery() string
+	TableColumnsQuery() string
+}
+
 // Dialect provides engine-specific SQL fragments.
+// It composes all sub-interfaces, so any value that implements Dialect
+// also satisfies TypeMapper, DDLWriter, QueryWriter, Identifier, and Inspector.
 // Implementations return raw SQL strings that callers compose into full queries.
 type Dialect interface {
+	TypeMapper
+	DDLWriter
+	QueryWriter
+	Identifier
+	Inspector
 	// Engine returns the engine identifier (used as the driver name for sql.Open).
 	Engine() Engine
-
-	// Pagination returns the pagination clause for the engine.
-	//   MSSQL:    "OFFSET @Offset ROWS FETCH NEXT @Limit ROWS ONLY"
-	//   SQLite:   "LIMIT @Limit OFFSET @Offset"
-	//   Postgres: "LIMIT @Limit OFFSET @Offset"
-	Pagination() string
-
-	// AutoIncrement returns the column definition fragment for an auto-incrementing primary key.
-	//   MSSQL:    "INT PRIMARY KEY IDENTITY(1,1)"
-	//   SQLite:   "INTEGER PRIMARY KEY AUTOINCREMENT"
-	//   Postgres: "SERIAL PRIMARY KEY"
-	AutoIncrement() string
-
-	// Now returns the SQL expression for the current timestamp.
-	//   MSSQL:    "GETDATE()"
-	//   SQLite:   "CURRENT_TIMESTAMP"
-	//   Postgres: "NOW()"
-	Now() string
-
-	// TimestampType returns the column type for timestamps.
-	//   MSSQL:    "DATETIME"
-	//   SQLite:   "TIMESTAMP"
-	//   Postgres: "TIMESTAMPTZ"
-	TimestampType() string
-
-	// StringType returns the preferred string column type for the engine.
-	// Use this when you want the engine's best string representation.
-	//   MSSQL:    "NVARCHAR(255)" — Unicode-aware, preferred for text data
-	//   SQLite:   "TEXT"          — SQLite ignores length, all strings are TEXT
-	//   Postgres: "TEXT"          — Postgres TEXT has no performance penalty vs VARCHAR
-	StringType(maxLen int) string
-
-	// VarcharType returns an exact VARCHAR(n) column type.
-	// Use this when you need an explicit length-limited VARCHAR, e.g. for
-	// compatibility with existing schemas or when the distinction matters.
-	//   MSSQL:    "VARCHAR(255)"  — non-Unicode; use StringType for NVARCHAR
-	//   SQLite:   "TEXT"          — SQLite ignores length constraints
-	//   Postgres: "VARCHAR(255)"  — equivalent to TEXT with a CHECK, rarely needed
-	VarcharType(maxLen int) string
-
-	// IntType returns the column type for an integer.
-	//   MSSQL:    "INT"
-	//   SQLite:   "INTEGER"
-	//   Postgres: "INTEGER"
-	IntType() string
-
-	// TextType returns the column type for unlimited text.
-	//   MSSQL:    "NVARCHAR(MAX)"
-	//   SQLite:   "TEXT"
-	//   Postgres: "TEXT"
-	TextType() string
-
-	// BoolType returns the column type for booleans.
-	//   MSSQL:    "BIT"
-	//   SQLite:   "INTEGER"
-	//   Postgres: "BOOLEAN"
-	BoolType() string
-
-	// Placeholder returns the parameter placeholder for the nth argument (1-based).
-	//   MSSQL:    "@p1"
-	//   SQLite:   "?"
-	//   Postgres: "$1"
-	Placeholder(n int) string
-
-	// ReturningClause returns a RETURNING clause for INSERT/UPDATE statements,
-	// or empty string if the engine doesn't support it.
-	// The columns parameter specifies which columns to return (e.g., "id" or "id, created_at").
-	//   MSSQL:    ""                          (not supported)
-	//   SQLite:   "RETURNING <columns>"       (SQLite 3.35+)
-	//   Postgres: "RETURNING <columns>"
-	ReturningClause(columns string) string
-
-	// NormalizeIdentifier transforms a column or table name to the engine's
-	// idiomatic form. Postgres converts CamelCase to snake_case; other
-	// engines return the name unchanged.
-	NormalizeIdentifier(name string) string
-
-	// QuoteIdentifier quotes a SQL identifier (table name, column name, index name)
-	// using the engine-specific quoting style.
-	//   MSSQL:    [users]
-	//   SQLite:   "users"
-	//   Postgres: "users"
-	QuoteIdentifier(name string) string
-
-	// BigIntType returns the column type for a 64-bit integer.
-	//   MSSQL:    "BIGINT"
-	//   SQLite:   "INTEGER"
-	//   Postgres: "BIGINT"
-	BigIntType() string
-
-	// FloatType returns the column type for a floating-point number.
-	//   MSSQL:    "FLOAT"
-	//   SQLite:   "REAL"
-	//   Postgres: "DOUBLE PRECISION"
-	FloatType() string
-
-	// DecimalType returns the column type for an exact numeric with precision and scale.
-	//   MSSQL:    "DECIMAL(10,2)"
-	//   SQLite:   "REAL"
-	//   Postgres: "NUMERIC(10,2)"
-	DecimalType(precision, scale int) string
-
-	// UUIDType returns the column type for UUIDs.
-	//   MSSQL:    "UNIQUEIDENTIFIER"
-	//   SQLite:   "TEXT"
-	//   Postgres: "UUID"
-	UUIDType() string
-
-	// JSONType returns the column type for JSON data.
-	//   MSSQL:    "NVARCHAR(MAX)"
-	//   SQLite:   "TEXT"
-	//   Postgres: "JSONB"
-	JSONType() string
-
-	// CreateTableIfNotExists wraps a CREATE TABLE body so that it only runs
-	// when the table does not already exist.
-	CreateTableIfNotExists(table, body string) string
-
-	// DropTableIfExists returns the statement to drop a table if it exists.
-	DropTableIfExists(table string) string
-
-	// CreateIndexIfNotExists returns the statement to create an index if it doesn't exist.
-	CreateIndexIfNotExists(indexName, table, columns string) string
-
-	// LastInsertIDQuery returns SQL to retrieve the last inserted ID, or empty string
-	// if the driver supports Result.LastInsertId() natively.
-	LastInsertIDQuery() string
-
-	// SupportsLastInsertID reports whether the driver supports Result.LastInsertId().
-	SupportsLastInsertID() bool
-
-	// TableExistsQuery returns a query that checks whether a table exists.
-	// The query accepts a single positional parameter for the table name
-	// and returns one row if the table exists.
-	TableExistsQuery() string
-
-	// TableColumnsQuery returns a query that lists column names for a table.
-	// The query accepts a single positional parameter for the table name
-	// and returns rows with a "name" column.
-	TableColumnsQuery() string
-
-	// InsertOrIgnore returns an idempotent INSERT statement that silently
-	// skips rows that would violate a unique constraint.
-	//   SQLite:   "INSERT OR IGNORE INTO t (cols) VALUES (vals)"
-	//   Postgres: "INSERT INTO t (cols) VALUES (vals) ON CONFLICT DO NOTHING"
-	//   MSSQL:    wraps the insert in an IF NOT EXISTS check using the first column
-	InsertOrIgnore(table, columns, values string) string
 }
 
 // QuoteColumns splits a comma-separated column list, normalizes and quotes each identifier.
 // Sort direction suffixes (ASC, DESC) are preserved and re-appended after quoting.
-func QuoteColumns(d Dialect, columns string) string {
+func QuoteColumns(d Identifier, columns string) string {
 	parts := strings.Split(columns, ",")
 	quoted := make([]string, len(parts))
 	for i, part := range parts {

--- a/mssql.go
+++ b/mssql.go
@@ -5,6 +5,16 @@ import (
 	"strings"
 )
 
+// Compile-time interface checks.
+var (
+	_ Dialect    = MSSQLDialect{}
+	_ TypeMapper = MSSQLDialect{}
+	_ DDLWriter  = MSSQLDialect{}
+	_ QueryWriter = MSSQLDialect{}
+	_ Identifier = MSSQLDialect{}
+	_ Inspector  = MSSQLDialect{}
+)
+
 // MSSQLDialect implements Dialect for Microsoft SQL Server.
 type MSSQLDialect struct{}
 

--- a/postgres.go
+++ b/postgres.go
@@ -2,6 +2,16 @@ package fraggle
 
 import "fmt"
 
+// Compile-time interface checks.
+var (
+	_ Dialect    = PostgresDialect{}
+	_ TypeMapper = PostgresDialect{}
+	_ DDLWriter  = PostgresDialect{}
+	_ QueryWriter = PostgresDialect{}
+	_ Identifier = PostgresDialect{}
+	_ Inspector  = PostgresDialect{}
+)
+
 // PostgresDialect implements Dialect for PostgreSQL.
 type PostgresDialect struct{}
 

--- a/sqlite.go
+++ b/sqlite.go
@@ -2,6 +2,16 @@ package fraggle
 
 import "fmt"
 
+// Compile-time interface checks.
+var (
+	_ Dialect    = SQLiteDialect{}
+	_ TypeMapper = SQLiteDialect{}
+	_ DDLWriter  = SQLiteDialect{}
+	_ QueryWriter = SQLiteDialect{}
+	_ Identifier = SQLiteDialect{}
+	_ Inspector  = SQLiteDialect{}
+)
+
 // SQLiteDialect implements Dialect for SQLite.
 type SQLiteDialect struct{}
 


### PR DESCRIPTION
## Summary

- Split the monolithic 30-method `Dialect` interface into five focused sub-interfaces: `TypeMapper`, `DDLWriter`, `QueryWriter`, `Identifier`, and `Inspector`
- `Dialect` composes all five sub-interfaces plus `Engine()`, so this is fully backwards compatible -- existing code that passes `Dialect` continues to work unchanged
- Narrowed function signatures where the full `Dialect` is not needed: `QuoteColumns` and dbrepo's `ColumnsQ`/`SetClauseQ`/`InsertIntoQ` now accept `Identifier`
- Added compile-time interface checks (`var _ TypeMapper = SQLiteDialect{}` etc.) for all three dialect implementations
- Updated README to document the sub-interface structure

## Test plan

- [x] `go test ./...` passes across all packages (fraggle, dbrepo, schema)
- [x] `go vet ./...` clean
- [x] All example tests pass
- [x] No changes to dialect implementations (SQLite, Postgres, MSSQL)
- [x] Backwards compatible: Dialect still embeds all sub-interfaces